### PR TITLE
Fix a crash related to ChunkSave using a deprecated constructor option

### DIFF
--- a/src/Save/ChunkSave.php
+++ b/src/Save/ChunkSave.php
@@ -221,7 +221,6 @@ class ChunkSave extends AbstractSave
             $finalPath,
             $this->file->getClientOriginalName(),
             $this->file->getClientMimeType(),
-            filesize($finalPath),
             $this->file->getError(),
             // we must pass the true as test to force the upload file
             // to use a standard copy method, not move uploaded file


### PR DESCRIPTION
ChunkSave is using a deprecated constructor option for the Symfony UploadedFile. Passing the filesize as the 4th argument was deprecated in Symfony 4.1, see https://github.com/symfony/symfony/commit/39622488bb100a2ca4b59ae9b1abac61467ed113#diff-d47b5088ba39eba76f0e12df25f8c098

The reason it used to work fine was because Symfony was automatically detecting and removing the filesize option when it was passed, and giving a silent error:

```
if (4 < \func_num_args() ? !\is_bool($test) : null !== $error && @filesize($path) === $error) {
     @trigger_error(sprintf('Passing a size as 4th argument to the constructor of "%s" is deprecated since Symfony 4.1.', __CLASS__), E_USER_DEPRECATED);
     $error = $test;
     $test = 5 < \func_num_args() ? func_get_arg(5) : false;
}
```

This handling of the deprecated option was removed in the most current versions of Laravel/Symfony, so calling it incorrectly now causes issues with the chunked upload handling. Specifically, when you try to move the completed file, you end up with a `The file "filename" was not uploaded due to an unknown error.` exception.